### PR TITLE
Adding Test AutomationU learning page

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Paul Maxwell-Walters [@TestingRants](https://twitter.com/TestingRants), paulwalt
 
 * [Webdriverio Documentation (Webdriver binding for nodejs)](http://webdriver.io/)
 
+* [Test Automation Learning Paths](https://testautomationu.applitools.com/)
+
 ## Test Reporting
 
 * [Test Execution Reports, SoftwareTestingHelp](http://www.softwaretestinghelp.com/test-execution-report/)


### PR DESCRIPTION
I added the link to Test Automation University's learning path. I realised only their Twitter page was added.